### PR TITLE
rails 4 now use strong_parameter

### DIFF
--- a/lib/acts_as_ordered_tree.rb
+++ b/lib/acts_as_ordered_tree.rb
@@ -66,10 +66,6 @@ module ActsAsOrderedTree
   module Columns
     extend ActiveSupport::Concern
 
-    included do
-      attr_protected depth_column, position_column
-    end
-
     def parent_column
       acts_as_ordered_tree_options[:parent_column]
     end


### PR DESCRIPTION
When use Rails 4 this lines raised
"RuntimeError: `attr_protected` is extracted out of Rails into a gem. Please use new recommended protection model for params(strong_parameters) or add `protected_attributes` to your Gemfile to use old one."
