### PR TITLE
Support arel builtin case node

### DIFF
--- a/gemfiles/rails3.1.gemfile
+++ b/gemfiles/rails3.1.gemfile
@@ -4,7 +4,7 @@ source "http://rubygems.org"
 
 gem "pg", :platform => :ruby
 gem "sqlite3", :platform => :ruby
-gem "mysql2", :platform => :ruby
+gem "mysql2", "~> 0.3.20", :platform => :ruby
 gem "simplecov", :platform => :ruby
 gem "coveralls", :platform => :ruby
 gem "activerecord-jdbcpostgresql-adapter", "~> 1.2.2", :platform => :jruby

--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -4,7 +4,7 @@ source "http://rubygems.org"
 
 gem "pg", :platform => :ruby
 gem "sqlite3", :platform => :ruby
-gem "mysql2", :platform => :ruby
+gem "mysql2", "~> 0.3.20", :platform => :ruby
 gem "simplecov", :platform => :ruby
 gem "coveralls", :platform => :ruby
 gem "activerecord-jdbcpostgresql-adapter", "~> 1.2.2", :platform => :jruby

--- a/gemfiles/rails4.0.gemfile
+++ b/gemfiles/rails4.0.gemfile
@@ -4,7 +4,7 @@ source "http://rubygems.org"
 
 gem "pg", :platform => :ruby
 gem "sqlite3", :platform => :ruby
-gem "mysql2", :platform => :ruby
+gem "mysql2", "~> 0.3.20", :platform => :ruby
 gem "simplecov", :platform => :ruby
 gem "coveralls", :platform => :ruby
 gem "activerecord-jdbcpostgresql-adapter", "~> 1.3.6", :platform => :jruby

--- a/gemfiles/rails4.1.gemfile
+++ b/gemfiles/rails4.1.gemfile
@@ -4,7 +4,7 @@ source "http://rubygems.org"
 
 gem "pg", :platform => :ruby
 gem "sqlite3", :platform => :ruby
-gem "mysql2", :platform => :ruby
+gem "mysql2", "~> 0.3.20", :platform => :ruby
 gem "simplecov", :platform => :ruby
 gem "coveralls", :platform => :ruby
 gem "activerecord-jdbcpostgresql-adapter", "~> 1.3.6", :platform => :jruby

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -4,12 +4,12 @@ source "http://rubygems.org"
 
 gem "pg", :platform => :ruby
 gem "sqlite3", :platform => :ruby
-gem "mysql2", :platform => :ruby
+gem "mysql2", "~> 0.4.2", :platform => :ruby
 gem "simplecov", :platform => :ruby
 gem "coveralls", :platform => :ruby
-gem "activerecord-jdbcpostgresql-adapter", "~> 1.3.6", :platform => :jruby
-gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.6", :platform => :jruby
+gem "activerecord-jdbcpostgresql-adapter", "~> 1.3.19", :platform => :jruby
+gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.19", :platform => :jruby
 gem "activerecord", "~> 4.2.0"
-gem "activerecord-jdbcmysql-adapter", "~> 1.3.6", :platform => :jruby
+gem "activerecord-jdbcmysql-adapter", "~> 1.3.19", :platform => :jruby
 
 gemspec :path => "../"

--- a/lib/acts_as_ordered_tree/transaction/dsl.rb
+++ b/lib/acts_as_ordered_tree/transaction/dsl.rb
@@ -2,105 +2,107 @@
 
 require 'active_support/core_ext/string/inflections'
 
-module Arel
-  module Nodes
-    # Case node
-    #
-    # @example
-    #   switch.when(table[:x].gt(1), table[:y]).else(table[:z])
-    #   # CASE WHEN "table"."x" > 1 THEN "table"."y" ELSE "table"."z" END
-    #   switch.when(table[:x].gt(1)).then(table[:y]).else(table[:z])
-    class Case < Arel::Nodes::Node
-      include Arel::OrderPredications
-      include Arel::Predications
+unless defined? Arel::Nodes::Case
+  module Arel
+    module Nodes
+      # Case node
+      #
+      # @example
+      #   switch.when(table[:x].gt(1), table[:y]).else(table[:z])
+      #   # CASE WHEN "table"."x" > 1 THEN "table"."y" ELSE "table"."z" END
+      #   switch.when(table[:x].gt(1)).then(table[:y]).else(table[:z])
+      class Case < Arel::Nodes::Node
+        include Arel::OrderPredications
+        include Arel::Predications
 
-      attr_reader :conditions, :default
+        attr_reader :conditions, :default
 
-      def initialize
-        @conditions = []
-        @default = nil
+        def initialize
+          @conditions = []
+          @default = nil
+        end
+
+        def when(condition, expression = nil)
+          @conditions << When.new(condition, expression)
+          self
+        end
+
+        def then(expression)
+          @conditions.last.right = expression
+          self
+        end
+
+        def else(expression)
+          @default = Else.new(expression)
+          self
+        end
       end
 
-      def when(condition, expression = nil)
-        @conditions << When.new(condition, expression)
-        self
+      class When < Arel::Nodes::Binary
       end
 
-      def then(expression)
-        @conditions.last.right = expression
-        self
-      end
-
-      def else(expression)
-        @default = Else.new(expression)
-        self
+      class Else < Arel::Nodes::Unary
       end
     end
 
-    class When < Arel::Nodes::Binary
-    end
+    module Visitors
+      class ToSql < Arel::Visitors::ToSql.superclass
+        private
+        def visit_Arel_Nodes_Case o, *a
+          conditions = o.conditions.map { |x| visit x, *a }.join(' ')
+          default = o.default && visit(o.default, *a)
 
-    class Else < Arel::Nodes::Unary
-    end
-  end
+          "CASE #{[conditions, default].compact.join(' ')} END"
+        end
 
-  module Visitors
-    class ToSql < Arel::Visitors::ToSql.superclass
-      private
-      def visit_Arel_Nodes_Case o, *a
-        conditions = o.conditions.map { |x| visit x, *a }.join(' ')
-        default = o.default && visit(o.default, *a)
+        def visit_Arel_Nodes_When o, *a
+          "WHEN #{visit o.left, *a} THEN #{visit o.right, *a}"
+        end
 
-        "CASE #{[conditions, default].compact.join(' ')} END"
-      end
+        def visit_Arel_Nodes_Else o, *a
+          "ELSE #{visit o.expr, *a}"
+        end
 
-      def visit_Arel_Nodes_When o, *a
-        "WHEN #{visit o.left, *a} THEN #{visit o.right, *a}"
-      end
-
-      def visit_Arel_Nodes_Else o, *a
-        "ELSE #{visit o.expr, *a}"
-      end
-
-      if Arel::VERSION >= '6.0.0'
-        def visit_Arel_Nodes_Case o, collector
-          collector << 'CASE '
-          o.conditions.each do |x|
-            visit x, collector
-            collector << ' '
+        if Arel::VERSION >= '6.0.0'
+          def visit_Arel_Nodes_Case o, collector
+            collector << 'CASE '
+            o.conditions.each do |x|
+              visit x, collector
+              collector << ' '
+            end
+            if o.default
+              visit o.default, collector
+              collector << ' '
+            end
+            collector << 'END'
           end
-          if o.default
-            visit o.default, collector
-            collector << ' '
+
+          def visit_Arel_Nodes_When o, collector
+            collector << 'WHEN '
+            visit o.left, collector
+            collector << ' THEN '
+            visit o.right, collector
           end
-          collector << 'END'
-        end
 
-        def visit_Arel_Nodes_When o, collector
-          collector << 'WHEN '
-          visit o.left, collector
-          collector << ' THEN '
-          visit o.right, collector
-        end
+          def visit_Arel_Nodes_Else o, collector
+            collector << 'ELSE'
+            visit o.expr, collector
+          end
 
-        def visit_Arel_Nodes_Else o, collector
-          collector << 'ELSE'
-          visit o.expr, collector
-        end
-
-        def visit_NilClass o, collector
-          collector << 'NULL'
+          def visit_NilClass o, collector
+            collector << 'NULL'
+          end
         end
       end
-    end
 
-    class DepthFirst < Arel::Visitors::Visitor
-      def visit_Arel_Nodes_Case o, *a
-        visit o.conditions, *a
-        visit o.default, *a
+      class DepthFirst < Arel::Visitors::Visitor
+        def visit_Arel_Nodes_Case o, *a
+          visit o.conditions, *a
+          visit o.default, *a
+        end
+        alias :visit_Arel_Nodes_When :binary
+        alias :visit_Arel_Nodes_Else :unary
       end
-      alias :visit_Arel_Nodes_When :binary
-      alias :visit_Arel_Nodes_Else :unary
     end
   end
 end


### PR DESCRIPTION
An extended version of rhe Arel::Nodes::Case from this gem has been integrated into arel master shortly after 7.0.0, so try to use it if available.

This resolves #35.
